### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Mail/Autoconfig/Driver/Srv.php
+++ b/lib/Horde/Mail/Autoconfig/Driver/Srv.php
@@ -81,10 +81,12 @@ class Horde_Mail_Autoconfig_Driver_Srv extends Horde_Mail_Autoconfig_Driver
             foreach ($queries as $val2) {
                 try {
                     $res = $this->dns->query($val2 . '._tcp.' . $val, 'SRV');
-                    foreach ($res->answer as $val3) {
-                        if (strlen($val3->target)) {
-                            $val3->query = $val2;
-                            $obs[$val3->priority][] = $val3;
+                    if ( ($res != NULL) && (property_exists($res, 'answer')) ) {
+                        foreach ($res->answer as $val3) {
+                            if (strlen($val3->target)) {
+                                $val3->query = $val2;
+                                $obs[$val3->priority][] = $val3;
+                            }
                         }
                     }
                 } catch (Net_DNS2_Exception $e) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Mail/Autoconfig/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Mail/Autoconfig/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Mail_Autoconfig Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Mail/Autoconfig/AutoconfigTest.php
+++ b/test/Horde/Mail/Autoconfig/AutoconfigTest.php
@@ -27,7 +27,7 @@ class Horde_Mail_Autoconfig_AutoconfigTest extends Horde_Test_Case
 {
     private $aconfig;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->aconfig = new Horde_Mail_Autoconfig();
     }

--- a/test/Horde/Mail/Autoconfig/Driver/TestBase.php
+++ b/test/Horde/Mail/Autoconfig/Driver/TestBase.php
@@ -28,14 +28,14 @@ extends Horde_Test_Case
 {
     private $driver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->driver = $this->_getDriver();
     }
 
     abstract protected function _getDriver();
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->driver);
     }


### PR DESCRIPTION
- Debian changes: Fix tests against PHPUnit 8.x/9.x. https://salsa.debian.org/horde-team/php-horde-mail-autoconfig/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Don't access object property of a NULL object.
